### PR TITLE
fix(ci): copy launchpal-privhelper into app bundle during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         else
           go tool wails build
         fi
+        make install-helper
 
     - name: Install create-dmg
       run: brew install create-dmg


### PR DESCRIPTION
## Problem

v1.13.0 introduced `launchpal-privhelper` (PR #25) for Admin Mode, but the release DMG ships without it. Users hit:

```
helper_binary_not_found: helper binary not found at /Applications/launchpal.app/Contents/MacOS/launchpal-privhelper
```

when clicking **Enable Admin Mode**.

## Root cause

`Makefile`'s `build` target runs `wails build` then `install-helper` to copy the helper into the bundle:

```makefile
build:
    go tool wails build
    $(MAKE) install-helper
```

But `.github/workflows/build.yml` calls `go tool wails build` directly, bypassing `install-helper`. So every CI-built DMG (including the one Homebrew downloads) is missing the helper.

## Fix

Run `make install-helper` after `wails build` in the workflow. One line.

## Impact

- Affects all v1.13.0 users who installed via DMG or Homebrew cask.
- After this merges, a `v1.13.1` patch release should be cut so release-please updates the Homebrew tap automatically.

## Test plan

- The PR build run will produce a DMG; mount it and confirm `launchpal.app/Contents/MacOS/launchpal-privhelper` exists.